### PR TITLE
Lien vers notre documentation sur les tâches

### DIFF
--- a/doc/en/slurm/commands.rst
+++ b/doc/en/slurm/commands.rst
@@ -6,9 +6,10 @@ Commands
 Submitting jobs
 ---------------
 
-There are several options for submitting a computational job, but the first
-method below is preferred to avoid waiting on the command line and to avoid
-wasting computation time.
+There are several options for `submitting a computational job
+<https://docs.alliancecan.ca/wiki/Running_jobs>`__, but the first method below
+is preferred to avoid waiting on the command line and to avoid wasting
+computation time.
 
 #. Via a job script:
 

--- a/doc/fr/slurm/commands.rst
+++ b/doc/fr/slurm/commands.rst
@@ -6,9 +6,10 @@ Commandes
 Soumission de tâches
 --------------------
 
-Il existe plusieurs possibilités pour soumettre une tâche de calcul, mais la
-première méthode ci-dessous est à privilégier afin d'éviter d'attendre sur la
-ligne de commandes et pour éviter le gaspillage de temps de calcul.
+Il existe plusieurs possibilités pour `soumettre une tâche de calcul
+<https://docs.alliancecan.ca/wiki/Running_jobs/fr>`__, mais la première méthode
+ci-dessous est à privilégier afin d'éviter d'attendre sur la ligne de commandes
+et pour éviter le gaspillage de temps de calcul.
 
 #. Via un script de tâche :
 


### PR DESCRIPTION
Dans un des tableaux de post-mortem, j'avais noté qu'il serait bien d'avoir un lien vers la documentation pour la page des commandes. C'est chose faite.

J'avais aussi noté qu'il serait bien d'avoir les nombres à virgule flottante avec des `.` plutôt que des `,` dans les sorties de `top`. C'est à la fois pour se conformer aux images, mais aussi à ce qu'on voit sur le Magic Castle. Cependant, c'est fastidieux de changer toutes les `,` en `.`, alors j'ai laissé faire puisque c'est juste superficiel.

Bref, ça devrait être mon dernier pull request pour cet automne.